### PR TITLE
Use geo-pixel-stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+- "0.10.35"
+sudo: false

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "index.js",
   "author": "Mapbox (https://www.mapbox.com)",
   "dependencies": {
-    "gdal": "^0.4.1"
+    "gdal": "^0.4.1",
+    "geo-pixel-stream": "^0.1.1",
+    "queue-async": "^1.0.7",
+    "underscore": "^1.7.0"
   },
   "engines": {
     "node": "0.10.x"

--- a/test/test.js
+++ b/test/test.js
@@ -7,42 +7,42 @@ var gdal = require('gdal');
 
 
 tape('scale', function(assert) {
-  
+
   var srcpath = path.join(__dirname, 'fixtures', '16bit.tif');
   var dstpath = path.join(__dirname, 'fixtures', 'scaled.tif');
-  
+
   // This file was produced with gdal_translate
   var ctrlpath = path.join(__dirname, 'fixtures', '8bit.tif');
-  
+
   bytetiff.scale(srcpath, dstpath, function(error) {
-    
+
     ctrl = gdal.open(ctrlpath);
     dst = gdal.open(dstpath);
-    
+
     ctrl.bands.forEach(function(band) {
       var bidx = band.id;
-      
+
       var ctrlData = band.pixels.read(0, 0, 100, 100);
-      
+
       var dstband = dst.bands.get(bidx);
       var dstData = dstband.pixels.read(0, 0, 100, 100);
-      
+
       for (var i = 0; i < 100 * 100; i += 1) {
         assert.equal(ctrlData[i], dstData[i]);
       }
-      
+
     });
-    
+
     assert.end();
   });
-  
+
 });
 
 
 tape('teardown', function (test) {
-  
+
   var dstpath = path.join(__dirname, 'fixtures', 'scaled.tif');
   fs.unlink(dstpath);
-  
+
   test.end();
 });


### PR DESCRIPTION
This uses node's stream API via [geo-pixel-stream](https://github.com/mapbox/geo-pixel-stream) to keep memory usage low. I make no guarantees that it'll perform well, but shouldn't segfault on large images.

cc @kapadia 
