### PR TITLE
update gdal, node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-- "0.10.35"
+  - "4"
+  - "6"
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 0.4.0
+
+ - Upgraded to node-gdal@0.9.3
+ - Tests running on Node.js v4 & v6, no longer on v0.10.x

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bytetiff",
-  "version": "0.4.0",
+  "version": "0.3.0",
   "description": "",
   "main": "index.js",
   "author": "Mapbox (https://www.mapbox.com)",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "dependencies": {
     "gdal": "~0.9.3",
-    "geo-pixel-stream": "~0.3.0",
+    "geo-pixel-stream": "https://github.com/mapbox/geo-pixel-stream/tarball/tag-fiesta",
     "queue-async": "^1.0.7",
     "underscore": "^1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,17 +1,14 @@
 {
   "name": "bytetiff",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "",
   "main": "index.js",
   "author": "Mapbox (https://www.mapbox.com)",
   "dependencies": {
-    "gdal": "~0.8.0",
+    "gdal": "~0.9.3",
     "geo-pixel-stream": "~0.3.0",
     "queue-async": "^1.0.7",
     "underscore": "^1.7.0"
-  },
-  "engines": {
-    "node": "0.10.x"
   },
   "devDependencies": {
     "tape": "3.0.x"


### PR DESCRIPTION
- gdal updated to 0.9.3
- travis now testing on node v4, v6, no longer v0.10.x
- adds `CHANGELOG.md`

cc @springmeyer @who8mycakes @GretaCB 
