### PR TITLE
update changelog and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.4.0
+## 0.4.1
+
+ - Fix package.json that was pointing to a GitHub branch version of geo-pixel-stream
+
+## 0.4.0 (deprecated)
 
  - Upgraded to node-gdal@0.9.3
  - Tests running on Node.js v4 & v6, no longer on v0.10.x

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "dependencies": {
     "gdal": "~0.9.3",
-    "geo-pixel-stream": "https://github.com/mapbox/geo-pixel-stream/tarball/tag-fiesta",
+    "geo-pixel-stream": "0.4.0",
     "queue-async": "^1.0.7",
     "underscore": "^1.7.0"
   },


### PR DESCRIPTION
fixes my mistake of publishing `0.4.0` with the incorrect package.json gitURLs instead of versions
